### PR TITLE
fix: resolve semantic-release permission and repository URL issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,10 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
+  issues: write
   pull-requests: write
+  actions: write
 
 jobs:
   release:
@@ -19,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Test and validate
         uses: ./.github/actions/test-and-validate

--- a/package.json
+++ b/package.json
@@ -51,13 +51,13 @@
     "error-handling",
     "type-safe"
   ],
-  "homepage": "https://github.com/masstronaut/typesafe-ts#readme",
+  "homepage": "https://github.com/Masstronaut/typesafe-ts#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/masstronaut/typesafe-ts.git"
+    "url": "https://github.com/Masstronaut/typesafe-ts.git"
   },
   "bugs": {
-    "url": "https://github.com/masstronaut/typesafe-ts/issues"
+    "url": "https://github.com/Masstronaut/typesafe-ts/issues"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
## Summary
Fixes the issues that caused the initial release to fail.

## Root Causes
1. **Repository URL mismatch**: package.json had old lowercase 'masstronaut' URLs
2. **Insufficient GitHub Actions permissions**: semantic-release needs write access to push tags and create releases
3. **Missing git credentials**: checkout action wasn't persisting the GitHub token

## Changes
- ✅ Update all repository URLs in package.json to use correct capitalization
- ✅ Add required GitHub Actions permissions: contents:write, issues:write, actions:write  
- ✅ Fix checkout action to persist GitHub token for semantic-release git operations

## Impact
This will allow semantic-release to successfully:
- Push version tags to the repository
- Create GitHub releases
- Update package.json version
- Generate and commit CHANGELOG.md

Once merged, re-running the release workflow should complete successfully and publish v1.0.0 to npm.