### PR TITLE
fix: exclude semantic-release commits from commitlint validation

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -2,6 +2,10 @@ import type { UserConfig } from "@commitlint/types";
 
 const Configuration: UserConfig = {
   extends: ["@commitlint/config-conventional"],
+  ignores: [
+    // Skip commitlint for semantic-release commits
+    (message) => message.includes("chore(release):") && message.includes("[skip ci]"),
+  ],
   rules: {
     "type-enum": [
       2,


### PR DESCRIPTION
## Problem
Semantic-release generates commit messages with long URLs that violate the commitlint footer length limit, causing releases to fail.

## Solution
Add ignore pattern for semantic-release commits (containing 'chore(release):' and '[skip ci]') to allow automated releases to complete successfully.