### PR TITLE
chore: deprecate map_err in favor of map_error

### DIFF
--- a/src/result/readme.md
+++ b/src/result/readme.md
@@ -403,7 +403,7 @@ function readConfig(): Result<ConfigData, Error> {
         return JSON.parse(data);
     });
 
-    return result.map_err((error) => {
+    return result.map_error((error) => {
         console.error("Failed to read config:", error);
         return error;
     });
@@ -437,7 +437,7 @@ async function fetchUserData(id: string): Promise<Result<UserData, Error>> {
             const response = await fetch(`/api/users/${id}`);
             return await response.json();
         })
-        .map_err((error) => {
+        .map_error((error) => {
             console.error("Failed to fetch user:", error);
             return error;
         });


### PR DESCRIPTION
## Summary
- Renames `map_err` method to `map_error` for better clarity and consistency
- Maintains backward compatibility by keeping deprecated `map_err` methods
- Deprecated methods will be removed in the next major version release

## Changes
- Renamed `map_err` to `map_error` in both `Result` and `AsyncResult` interfaces
- Added deprecated `map_err` methods that call `map_error` internally
- Updated documentation examples to use `map_error`

## Breaking Changes
- None in this release - `map_err` is deprecated but still functional
- `map_err` will be removed in the next major version

## Test plan
- [x] All existing tests pass (no breaking changes)
- [x] Deprecated methods call the new methods correctly
- [x] Documentation updated with new method name