### PR TITLE
Add brand module for nominal typing and branded errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
         "./result/lint": {
             "types": "./dist/result/lint.d.ts",
             "default": "./dist/result/lint.js"
+        },
+        "./brand": {
+            "types": "./dist/brand/index.d.ts",
+            "default": "./dist/brand/index.js"
         }
     },
     "scripts": {
@@ -50,6 +54,9 @@
         "monads",
         "optional",
         "result",
+        "brand",
+        "branded-types",
+        "tagged-unions",
         "error-handling",
         "type-safe"
     ],

--- a/src/brand/brand.test.ts
+++ b/src/brand/brand.test.ts
@@ -1,0 +1,690 @@
+/*
+Copyright (c) 2025 Allan Deutsch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import { test } from "node:test";
+import assert from "node:assert";
+import { Assert, type Check } from "../assert/index.ts";
+import {
+    type Brand,
+    apply_brand,
+    brand_symbol,
+    branded_error,
+} from "./brand.ts";
+
+await test("Brand", async (t) => {
+    await t.test("produces a type error when used on a string", () => {
+        // @ts-expect-error basic types can't have symbol properties added to them.
+        type BrandedString = ReturnType<typeof apply_brand<string, "String">>; // eslint-disable-line @typescript-eslint/no-unused-vars
+    });
+
+    await t.test("produces a type error when used on a number", () => {
+        // @ts-expect-error basic types can't have symbol properties added to them.
+        type BrandedNumber = ReturnType<typeof apply_brand<number, "Number">>; // eslint-disable-line @typescript-eslint/no-unused-vars
+    });
+
+    await t.test("produces a type error when used on a boolean", () => {
+        // @ts-expect-error basic types can't have symbol properties added to them.
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        type BrandedBoolean = ReturnType<
+            // @ts-expect-error basic types can't have symbol properties added to them.
+            typeof apply_brand<boolean, "Boolean">
+        >;
+    });
+
+    await t.test("produces a type error when used on a symbol", () => {
+        // @ts-expect-error basic types can't have symbol properties added to them.
+        type BrandedSymbol = ReturnType<typeof apply_brand<symbol, "Symbol">>; // eslint-disable-line @typescript-eslint/no-unused-vars
+    });
+
+    await t.test("produces a type error when used on null", () => {
+        // @ts-expect-error basic types can't have symbol properties added to them.
+        type BrandedNull = ReturnType<typeof apply_brand<null, "Null">>; // eslint-disable-line @typescript-eslint/no-unused-vars
+    });
+
+    await t.test("produces a type error when used on undefined", () => {
+        // @ts-expect-error basic types can't have symbol properties added to them.
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        type BrandedUndefined = ReturnType<
+            // @ts-expect-error basic types can't have symbol properties added to them.
+            typeof apply_brand<undefined, "Undefined">
+        >;
+    });
+
+    await t.test("produces a type error when used on bigint", () => {
+        // @ts-expect-error basic types can't have symbol properties added to them.
+        type BrandedBigInt = ReturnType<typeof apply_brand<bigint, "BigInt">>; // eslint-disable-line @typescript-eslint/no-unused-vars
+    });
+
+    await t.test("works with function keyword syntax", () => {
+        function regularFunction(x: number): string {
+            return x.toString();
+        }
+
+        const brandedFunction = apply_brand(regularFunction, "TestFunction");
+
+        assert.strictEqual(brandedFunction[brand_symbol], "TestFunction");
+        assert.strictEqual(brandedFunction(42), "42");
+
+        type BrandedFunctionType = typeof brandedFunction;
+        Assert<
+            Check.Extends<
+                BrandedFunctionType,
+                Brand<typeof regularFunction, "TestFunction">
+            >
+        >();
+    });
+
+    await t.test("works with arrow function syntax", () => {
+        const arrowFunction = (x: number): string => x.toString();
+
+        const brandedArrowFunction = apply_brand(
+            arrowFunction,
+            "TestArrowFunction"
+        );
+
+        assert.strictEqual(
+            brandedArrowFunction[brand_symbol],
+            "TestArrowFunction"
+        );
+        assert.strictEqual(brandedArrowFunction(42), "42");
+
+        type BrandedArrowFunctionType = typeof brandedArrowFunction;
+        Assert<
+            Check.Extends<
+                BrandedArrowFunctionType,
+                Brand<typeof arrowFunction, "TestArrowFunction">
+            >
+        >();
+    });
+
+    await t.test("branded functions maintain correct typing", () => {
+        function namedFunc(a: string, b: number): boolean {
+            return a.length === b;
+        }
+        const arrowFunc = (a: string, b: number): boolean => a.length === b;
+
+        const brandedNamed = apply_brand(namedFunc, "NamedBrand");
+        const brandedArrow = apply_brand(arrowFunc, "ArrowBrand");
+
+        assert.strictEqual(brandedNamed("hello", 5), true);
+        assert.strictEqual(brandedArrow("world", 5), true);
+        assert.strictEqual(brandedNamed[brand_symbol], "NamedBrand");
+        assert.strictEqual(brandedArrow[brand_symbol], "ArrowBrand");
+
+        type NamedType = typeof brandedNamed;
+        type ArrowType = typeof brandedArrow;
+
+        Assert<Check.Extends<NamedType, (a: string, b: number) => boolean>>();
+        Assert<Check.Extends<ArrowType, (a: string, b: number) => boolean>>();
+        Assert<
+            Check.Extends<NamedType, Brand<typeof namedFunc, "NamedBrand">>
+        >();
+        Assert<
+            Check.Extends<ArrowType, Brand<typeof arrowFunc, "ArrowBrand">>
+        >();
+    });
+
+    await t.test("branded void functions remain invokable", () => {
+        let sideEffect = 0;
+
+        function voidFunc(): void {
+            sideEffect = 42;
+        }
+
+        const brandedVoidFunc = apply_brand(voidFunc, "VoidBrand");
+
+        assert.strictEqual(sideEffect, 0);
+        brandedVoidFunc();
+        assert.strictEqual(sideEffect, 42);
+        assert.strictEqual(brandedVoidFunc[brand_symbol], "VoidBrand");
+
+        type VoidType = typeof brandedVoidFunc;
+        Assert<Check.Extends<VoidType, () => void>>();
+        Assert<Check.Extends<VoidType, Brand<typeof voidFunc, "VoidBrand">>>();
+    });
+
+    await t.test(
+        "branded closures maintain side-effects on captured values",
+        () => {
+            let capturedValue = 10;
+            let anotherCaptured = "initial";
+
+            const closure = (increment: number, newString: string) => {
+                capturedValue += increment;
+                anotherCaptured = newString;
+                return capturedValue * 2;
+            };
+
+            const brandedClosure = apply_brand(closure, "ClosureBrand");
+
+            assert.strictEqual(capturedValue, 10);
+            assert.strictEqual(anotherCaptured, "initial");
+
+            const result1 = brandedClosure(5, "modified");
+            assert.strictEqual(result1, 30);
+            assert.strictEqual(capturedValue, 15);
+            assert.strictEqual(anotherCaptured, "modified");
+
+            const result2 = brandedClosure(3, "final");
+            assert.strictEqual(result2, 36);
+            assert.strictEqual(capturedValue, 18);
+            assert.strictEqual(anotherCaptured, "final");
+
+            assert.strictEqual(brandedClosure[brand_symbol], "ClosureBrand");
+
+            type ClosureType = typeof brandedClosure;
+            Assert<
+                Check.Extends<
+                    ClosureType,
+                    (increment: number, newString: string) => number
+                >
+            >();
+            Assert<
+                Check.Extends<
+                    ClosureType,
+                    Brand<typeof closure, "ClosureBrand">
+                >
+            >();
+        }
+    );
+
+    await t.test("branded variadic functions work correctly", () => {
+        function sum(...numbers: number[]): number {
+            return numbers.reduce((acc, num) => acc + num, 0);
+        }
+
+        const brandedSum = apply_brand(sum, "SumBrand");
+
+        Assert<
+            Check.Equal<ReturnType<typeof brandedSum>, ReturnType<typeof sum>>,
+            "Branding a function shouldn't change its return type."
+        >();
+        Assert<
+            Check.Equal<Parameters<typeof brandedSum>, Parameters<typeof sum>>,
+            "Branding a function shouldn't change its parameter types."
+        >();
+
+        assert.strictEqual(brandedSum(), 0);
+        assert.strictEqual(brandedSum(1), 1);
+        assert.strictEqual(brandedSum(1, 2, 3), 6);
+        assert.strictEqual(brandedSum(10, 20, 30, 40), 100);
+
+        assert.strictEqual(brandedSum[brand_symbol], "SumBrand");
+
+        type SumType = typeof brandedSum;
+
+        Assert<Check.Extends<SumType, (...numbers: number[]) => number>>();
+        Assert<Check.Extends<SumType, Brand<typeof sum, "SumBrand">>>();
+    });
+
+    await t.test("works with empty arrays", () => {
+        const emptyArray: number[] = [];
+        const brandedEmpty = apply_brand(emptyArray, "EmptyArray");
+
+        assert.strictEqual(brandedEmpty[brand_symbol], "EmptyArray");
+        assert.strictEqual(brandedEmpty.length, 0);
+
+        type EmptyArrayType = typeof brandedEmpty;
+        Assert<Check.Extends<EmptyArrayType, number[]>>();
+        Assert<Check.Extends<EmptyArrayType, Brand<number[], "EmptyArray">>>();
+    });
+
+    await t.test("works with arrays of intrinsic types", () => {
+        const numbers = [1, 2, 3];
+        const strings = ["hello", "world"];
+        const booleans = [true, false];
+
+        const brandedNumbers = apply_brand(numbers, "Numbers");
+        const brandedStrings = apply_brand(strings, "Strings");
+        const brandedBooleans = apply_brand(booleans, "Booleans");
+
+        assert.strictEqual(brandedNumbers[brand_symbol], "Numbers");
+        assert.strictEqual(brandedStrings[brand_symbol], "Strings");
+        assert.strictEqual(brandedBooleans[brand_symbol], "Booleans");
+
+        type NumberArrayType = typeof brandedNumbers;
+        type StringArrayType = typeof brandedStrings;
+        type BooleanArrayType = typeof brandedBooleans;
+
+        Assert<Check.Extends<NumberArrayType, number[]>>();
+        Assert<Check.Extends<StringArrayType, string[]>>();
+        Assert<Check.Extends<BooleanArrayType, boolean[]>>();
+        Assert<Check.Extends<NumberArrayType, Brand<number[], "Numbers">>>();
+        Assert<Check.Extends<StringArrayType, Brand<string[], "Strings">>>();
+        Assert<Check.Extends<BooleanArrayType, Brand<boolean[], "Booleans">>>();
+    });
+
+    await t.test("works with arrays of user-defined types", () => {
+        interface User {
+            id: number;
+            name: string;
+        }
+
+        const users: User[] = [{ id: 1, name: "Alice" }];
+        const brandedUsers = apply_brand(users, "Users");
+
+        assert.strictEqual(brandedUsers[brand_symbol], "Users");
+        assert.deepStrictEqual(brandedUsers, users);
+
+        type UserArrayType = typeof brandedUsers;
+        Assert<Check.Extends<UserArrayType, User[]>>();
+        Assert<Check.Extends<UserArrayType, Brand<User[], "Users">>>();
+        Assert<Check.Equal<UserArrayType[number], User>>();
+    });
+
+    await t.test("works with tuples", () => {
+        const tuple: [string, number] = ["test", 42];
+        const brandedTuple = apply_brand(tuple, "Tuple");
+
+        assert.strictEqual(brandedTuple[brand_symbol], "Tuple");
+        assert.strictEqual(brandedTuple.length, 2);
+        assert.strictEqual(brandedTuple[0], "test");
+        assert.strictEqual(brandedTuple[1], 42);
+
+        type TupleType = typeof brandedTuple;
+        Assert<Check.Extends<TupleType, [string, number]>>();
+        Assert<Check.Extends<TupleType, Brand<[string, number], "Tuple">>>();
+    });
+
+    await t.test("branding an array doesn't create a copy", () => {
+        const original = [1, 2, 3];
+        const branded = apply_brand(original, "TestArray");
+
+        assert.strictEqual(branded, original);
+        assert.strictEqual(branded[brand_symbol], "TestArray");
+    });
+
+    await t.test("branded arrays still support array operations", () => {
+        const numbers = [1, 2, 3];
+        const branded = apply_brand(numbers, "Numbers");
+
+        Assert<Check.Equal<(typeof branded)[number], number>>();
+
+        branded.push(4);
+        assert.strictEqual(branded.length, 4);
+        assert.strictEqual(branded[3], 4);
+
+        const sum = branded.reduce((acc, num) => acc + num, 0);
+        assert.strictEqual(sum, 10);
+
+        const doubled = branded.map((x) => x * 2);
+        assert.deepStrictEqual(doubled, [2, 4, 6, 8]);
+
+        assert.strictEqual(branded[brand_symbol], "Numbers");
+    });
+
+    await t.test("branded arrays preserve brand after mutation", () => {
+        const array = [1, 2];
+        const branded = apply_brand(array, "Mutable");
+
+        branded.push(3);
+        branded[0] = 99;
+        // eslint-disable-next-line typesafe-ts/enforce-optional-usage
+        branded.pop();
+
+        assert.strictEqual(branded[brand_symbol], "Mutable");
+        assert.strictEqual(branded[0], 99);
+        assert.strictEqual(branded[1], 2);
+        assert.strictEqual(branded.length, 2);
+    });
+
+    await t.test("tuple destructuring works with branded tuples", () => {
+        const tuple: [string, number] = ["hello", 42];
+        const branded = apply_brand(tuple, "DestructureTuple");
+
+        const [first, second] = branded;
+        assert.strictEqual(first, "hello");
+        assert.strictEqual(second, 42);
+        assert.strictEqual(branded[brand_symbol], "DestructureTuple");
+    });
+
+    await t.test("works with plain objects", () => {
+        const obj = { name: "Alice", age: 30 };
+        const branded = apply_brand(obj, "Person");
+
+        assert.strictEqual(branded[brand_symbol], "Person");
+        assert.strictEqual(branded.name, "Alice");
+        assert.strictEqual(branded.age, 30);
+
+        type PersonType = typeof branded;
+        Assert<Check.Extends<PersonType, { name: string; age: number }>>();
+        Assert<Check.Extends<PersonType, Brand<typeof obj, "Person">>>();
+        Assert<Check.Equal<Pick<PersonType, keyof typeof obj>, typeof obj>>();
+    });
+
+    await t.test("works with objects containing methods", () => {
+        const obj = {
+            value: 42,
+            getValue(): number {
+                return this.value;
+            },
+            setValue(newValue: number): void {
+                this.value = newValue;
+            },
+        };
+
+        const branded = apply_brand(obj, "Calculator");
+
+        assert.strictEqual(branded[brand_symbol], "Calculator");
+        assert.strictEqual(branded.getValue(), 42);
+
+        branded.setValue(100);
+        assert.strictEqual(branded.getValue(), 100);
+        assert.strictEqual(branded.value, 100);
+
+        type CalculatorType = typeof branded;
+        Assert<Check.Extends<CalculatorType, typeof obj>>();
+        Assert<
+            Check.Extends<CalculatorType, Brand<typeof obj, "Calculator">>
+        >();
+        Assert<
+            Check.Equal<Pick<CalculatorType, keyof typeof obj>, typeof obj>
+        >();
+    });
+
+    await t.test("works with class instances", () => {
+        class Rectangle {
+            constructor(width: number, height: number) {
+                this.width = width;
+                this.height = height;
+            }
+            width: number;
+            height: number;
+            area(): number {
+                return this.width * this.height;
+            }
+        }
+
+        const rect = new Rectangle(10, 20);
+        const branded = apply_brand(rect, "Shape");
+
+        assert.strictEqual(branded[brand_symbol], "Shape");
+        assert.strictEqual(branded.width, 10);
+        assert.strictEqual(branded.height, 20);
+        assert.strictEqual(branded.area(), 200);
+
+        type ShapeType = typeof branded;
+        Assert<Check.Extends<ShapeType, Rectangle>>();
+        Assert<Check.Extends<ShapeType, Brand<Rectangle, "Shape">>>();
+        Assert<Check.Equal<Pick<ShapeType, keyof Rectangle>, Rectangle>>();
+    });
+
+    await t.test("works with class inheritance", () => {
+        class Animal {
+            constructor(name: string) {
+                this.name = name;
+            }
+            name: string;
+            speak(): string {
+                return `${this.name} makes a sound`;
+            }
+        }
+
+        class Dog extends Animal {
+            constructor(name: string, breed: string) {
+                super(name);
+                this.breed = breed;
+            }
+            breed: string;
+            override speak(): string {
+                return `${this.name} barks`;
+            }
+        }
+
+        const dog = new Dog("Rex", "Golden Retriever");
+        const branded = apply_brand(dog, "Pet");
+
+        assert.strictEqual(branded[brand_symbol], "Pet");
+        assert.strictEqual(branded.name, "Rex");
+        assert.strictEqual(branded.breed, "Golden Retriever");
+        assert.strictEqual(branded.speak(), "Rex barks");
+        assert.ok(branded instanceof Dog);
+        assert.ok(branded instanceof Animal);
+
+        type PetType = typeof branded;
+        Assert<Check.Extends<PetType, Dog>>();
+        Assert<Check.Extends<PetType, Brand<Dog, "Pet">>>();
+        Assert<Check.Equal<Pick<PetType, keyof Dog>, Dog>>();
+    });
+
+    await t.test("branding an object doesn't create a copy", () => {
+        const original = { x: 1, y: 2 };
+        const branded = apply_brand(original, "Point");
+
+        assert.strictEqual(branded, original);
+        assert.strictEqual(branded[brand_symbol], "Point");
+    });
+
+    await t.test("branded objects still support property access", () => {
+        const obj = { count: 0, items: ["a", "b"] };
+        const branded = apply_brand(obj, "Container");
+
+        branded.count = 5;
+        branded.items.push("c");
+
+        assert.strictEqual(branded.count, 5);
+        assert.deepStrictEqual(branded.items, ["a", "b", "c"]);
+        assert.strictEqual(branded[brand_symbol], "Container");
+    });
+
+    await t.test("branded objects still support method calls", () => {
+        const obj = {
+            counter: 0,
+            increment(): number {
+                return ++this.counter;
+            },
+            getCounter(): number {
+                return this.counter;
+            },
+        };
+
+        const branded = apply_brand(obj, "Counter");
+
+        assert.strictEqual(branded.increment(), 1);
+        assert.strictEqual(branded.increment(), 2);
+        assert.strictEqual(branded.getCounter(), 2);
+        assert.strictEqual(branded[brand_symbol], "Counter");
+    });
+
+    await t.test("branded objects preserve brand after mutation", () => {
+        const obj = { data: "initial" };
+        const branded = apply_brand(obj, "Mutable");
+
+        branded.data = "modified";
+        Object.assign(branded, { extra: "property" });
+
+        assert.strictEqual(branded[brand_symbol], "Mutable");
+        assert.strictEqual(branded.data, "modified");
+        assert.strictEqual("extra" in branded, true);
+    });
+
+    await t.test("branded class instances preserve inheritance", () => {
+        class Base {
+            baseMethod(): string {
+                return "base";
+            }
+        }
+
+        class Derived extends Base {
+            derivedMethod(): string {
+                return "derived";
+            }
+        }
+
+        const instance = new Derived();
+        const branded = apply_brand(instance, "Inherited");
+
+        assert.strictEqual(branded[brand_symbol], "Inherited");
+        assert.strictEqual(branded.baseMethod(), "base");
+        assert.strictEqual(branded.derivedMethod(), "derived");
+        assert.ok(branded instanceof Derived);
+        assert.ok(branded instanceof Base);
+
+        type InheritedType = typeof branded;
+        Assert<Check.Equal<Pick<InheritedType, keyof Derived>, Derived>>();
+    });
+
+    await t.test("brand symbol discriminates union of error types", () => {
+        class ValidationError extends Error {
+            constructor(message: string) {
+                super(message);
+            }
+        }
+
+        class PasswordTooShortError extends ValidationError {
+            minLength: number;
+            constructor(message: string, minLength: number) {
+                super(message);
+                this.minLength = minLength;
+            }
+        }
+
+        class PasswordNoNumberError extends ValidationError {}
+
+        class PasswordNoSpecialCharError extends ValidationError {}
+
+        type BrandedTooShort = Brand<
+            PasswordTooShortError,
+            "PasswordTooShortError"
+        >;
+        type BrandedNoNumber = Brand<
+            PasswordNoNumberError,
+            "PasswordNoNumberError"
+        >;
+        type BrandedNoSpecial = Brand<
+            PasswordNoSpecialCharError,
+            "PasswordNoSpecialCharError"
+        >;
+        type ErrorUnion = BrandedTooShort | BrandedNoNumber | BrandedNoSpecial;
+
+        const error: ErrorUnion = apply_brand(
+            new PasswordTooShortError(
+                "Password must be at least 8 characters",
+                8
+            ),
+            "PasswordTooShortError"
+        ) as ErrorUnion;
+
+        type BrandType = (typeof error)[typeof brand_symbol];
+
+        Assert<
+            Check.Equal<
+                BrandType,
+                | "PasswordTooShortError"
+                | "PasswordNoNumberError"
+                | "PasswordNoSpecialCharError"
+            >
+        >();
+
+        switch (error[brand_symbol]) {
+            case "PasswordTooShortError": {
+                type NarrowedType = typeof error;
+                Assert<Check.Equal<NarrowedType, BrandedTooShort>>();
+
+                assert.ok(error instanceof PasswordTooShortError);
+                assert.strictEqual(
+                    error.message,
+                    "Password must be at least 8 characters"
+                );
+                assert.strictEqual(error.minLength, 8);
+                break;
+            }
+            case "PasswordNoNumberError": {
+                type NarrowedType = typeof error;
+                Assert<Check.Equal<NarrowedType, BrandedNoNumber>>();
+
+                assert.ok(error instanceof PasswordNoNumberError);
+                assert.strictEqual(
+                    error.message,
+                    "Password must be at least 8 characters"
+                );
+                break;
+            }
+            case "PasswordNoSpecialCharError": {
+                type NarrowedType = typeof error;
+                Assert<Check.Equal<NarrowedType, BrandedNoSpecial>>();
+
+                assert.ok(error instanceof PasswordNoSpecialCharError);
+                assert.strictEqual(
+                    error.message,
+                    "Password must be at least 8 characters"
+                );
+                break;
+            }
+        }
+    });
+
+    await t.test("brand symbol variable discriminates union types", () => {
+        class TooShortError extends branded_error("PasswordTooShort") {}
+        class NoNumberError extends branded_error("PasswordNoNumber") {}
+        class NoSpecialCharError extends branded_error(
+            "PasswordNoSpecialChar"
+        ) {}
+
+        // eslint-disable-next-line typesafe-ts/enforce-optional-usage
+        function validatePassword(password: string) {
+            if (password.length < 8) return new TooShortError();
+            if (!/\d/.test(password)) return new NoNumberError();
+            if (!/[!@#$%^&*]/.test(password)) return new NoSpecialCharError();
+            return null;
+        }
+
+        const validationError = validatePassword("short");
+        if (!validationError) {
+            assert.fail("Expected validation error");
+        }
+
+        const errorBrand = validationError[brand_symbol];
+
+        type ErrorBrandType = typeof errorBrand;
+        Assert<
+            Check.Equal<
+                ErrorBrandType,
+                | "PasswordTooShort"
+                | "PasswordNoNumber"
+                | "PasswordNoSpecialChar"
+            >
+        >();
+
+        switch (errorBrand) {
+            case "PasswordTooShort": {
+                type NarrowedBrandType = typeof errorBrand;
+                Assert<Check.Equal<NarrowedBrandType, "PasswordTooShort">>();
+
+                type NarrowedErrorType = typeof validationError;
+                Assert<Check.Equal<NarrowedErrorType, TooShortError>>();
+
+                assert.strictEqual(errorBrand, "PasswordTooShort");
+                assert.strictEqual(validationError.message, "PasswordTooShort");
+                break;
+            }
+            case "PasswordNoNumber": {
+                type NarrowedBrandType = typeof errorBrand;
+                Assert<Check.Equal<NarrowedBrandType, "PasswordNoNumber">>();
+
+                type NarrowedErrorType = typeof validationError;
+                Assert<Check.Equal<NarrowedErrorType, NoNumberError>>();
+
+                assert.fail("Should not reach this case");
+            }
+            case "PasswordNoSpecialChar": {
+                type NarrowedBrandType = typeof errorBrand;
+                Assert<
+                    Check.Equal<NarrowedBrandType, "PasswordNoSpecialChar">
+                >();
+
+                type NarrowedErrorType = typeof validationError;
+                Assert<Check.Equal<NarrowedErrorType, NoSpecialCharError>>();
+
+                assert.fail("Should not reach this case");
+            }
+        }
+    });
+});

--- a/src/brand/brand.ts
+++ b/src/brand/brand.ts
@@ -1,0 +1,192 @@
+/*
+Copyright (c) 2025 Allan Deutsch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+/**
+ * Unique symbol used to store brand identifiers on branded values.
+ * Guarantees no conflicts with properties from other libraries or user code.
+ */
+const brand_symbol = Symbol.for("brand");
+
+type BrandableTypes = ((...args: unknown[]) => unknown) | object;
+/**
+ * A branded type that combines a base type with a unique brand identifier.
+ * Brands create nominal types in TypeScript, making structurally equivalent values non-assignable.
+ * This is the type returned by `apply_brand()` / `brand.apply()`.
+ * The runtime brand set by apply_brand/brand.apply can be used as a union discriminant at runtime.
+ *
+ * The brand is stored using a unique symbol (`brand.symbol`), which guarantees it will not conflict
+ * with any properties from other tools, libraries, or your own code.
+ *
+ * @template T - The underlying type to be branded
+ * @template Brand - A string literal type that serves as the unique brand identifier
+ */
+type Brand<T extends BrandableTypes, Brand extends string> = T & {
+    readonly [brand_symbol]: Brand;
+};
+
+/**
+ * Error type for cleaner IDE error messages when attempting to brand an already branded type.
+ *
+ * @template T - The underlying type of the already branded value
+ * @template BrandString - The existing brand string of the already branded type
+ */
+type TypeAlreadyBrandedError<T, BrandString extends string> = {
+    error: `The type you've provided is already branded with the brand "${BrandString}"`;
+    underlyingType: T;
+};
+
+/**
+ * Modifies a value by applying a runtime brand.
+ * Brands can be used to create nominal types in TypeScript so that structurally equivalent values are not assignable.
+ * At runtime the brand can be used to discriminate union types and works reliably even in cases where `instanceof` does not.
+ *
+ * The brand is stored using a unique symbol (`brand.symbol`), which guarantees it will not conflict
+ * with any properties from other tools, libraries, or your own code.
+ *
+ * @param value The value to apply a brand to.
+ * @param brand_string A string literal used to create a unique brand type and runtime brand.
+ * @returns The input value with its type modified to include the brand, and a non-enumerable property added to the runtime value.
+ *
+ * @example Use a brand to create nominal types
+ * ```ts
+ * import { brand, type Brand } from "typesafe-ts/brand";
+ *
+ * type UserId = Brand<{ id: string }, "UserId">;
+ * type ProductId = Brand<{ id: string }, "ProductId">;
+ *
+ * const userId: UserId = brand.apply({ id: "user-123" }, "UserId");
+ * const productId: ProductId = brand.apply({ id: "prod-456" }, "ProductId");
+ *
+ * function getUser(id: UserId) { ... }
+ *
+ * getUser(userId);     // OK
+ * getUser(productId);  // Type error: ProductId is not assignable to UserId
+ * ```
+ */
+function apply_brand<
+    T extends BrandableTypes,
+    const BrandString extends string,
+>(
+    value: T extends Brand<infer UnderlyingType, infer ExistingBrand>
+        ? TypeAlreadyBrandedError<UnderlyingType, ExistingBrand>
+        : T,
+    brand_string: BrandString
+) {
+    const result = value as Brand<T, BrandString>;
+    (result as { [brand_symbol]: BrandString })[brand_symbol] = brand_string;
+    return result;
+}
+
+/**
+ * Creates a branded error class factory.
+ * The returned class can be extended with custom error data.
+ *
+ * @param brand_string A string literal used as the error name and brand identifier
+ * @returns A class constructor that creates branded Error instances
+ * @example Create discriminated error types for validation
+ * ```ts
+ * import { brand } from "typesafe-ts/brand";
+ *
+ * class TooShortError extends brand.Error("PasswordTooShort")<{ minLength: number }> {}
+ * class NoNumberError extends brand.Error("PasswordNoNumber") {}
+ *
+ * function validatePassword(password: string) {
+ *   if (password.length < 8) return new TooShortError({ minLength: 8 });
+ *   if (!/\d/.test(password)) return new NoNumberError();
+ *   return null;
+ * }
+ *
+ * const validationError = validatePassword("short");
+ * if (!validationError) return;
+ *
+ * const errorBrand = validationError[brand.symbol];
+ * switch (errorBrand) {
+ *   case "PasswordTooShort":
+ *     // validationError is narrowed to TooShortError
+ *     console.log(`Password must be at least ${validationError.minLength} characters`);
+ *     break;
+ *   case "PasswordNoNumber":
+ *     // validationError is narrowed to NoNumberError
+ *     console.log("Password must contain a number");
+ *     break;
+ * }
+ * ```
+ */
+function branded_error<const BrandString extends string>(
+    brand_string: BrandString
+) {
+    abstract class CustomError<
+        Data extends Record<string, unknown> = Record<string, never>,
+    > extends Error {
+        constructor(data?: Data & { message?: string }) {
+            const message = data?.message ?? brand_string;
+            super(message);
+
+            if (data) {
+                Object.assign(this, data);
+            }
+
+            if (Error.captureStackTrace) {
+                Error.captureStackTrace(this, this.constructor);
+            }
+        }
+    }
+
+    type BrandedErrorCustomData<ErrorData extends Record<string, unknown>> = {
+        [Key in keyof ErrorData as Key extends keyof Error
+            ? never
+            : Key]: ErrorData[Key];
+    } & { message?: string; cause?: unknown };
+
+    type BrandedErrorType<
+        BrandString extends string,
+        ErrorData extends Record<string, unknown>,
+    > = CustomError & {
+        readonly [brand_symbol]: BrandString;
+    } & BrandedErrorCustomData<ErrorData>;
+
+    const BrandedError = <BrandString extends string>(
+        brand: BrandString
+    ): new <ErrorData extends Record<string, unknown> = Record<string, never>>(
+        args: [Record<string, never>] extends [ErrorData]
+            ? void | { message?: string; cause?: unknown }
+            : BrandedErrorCustomData<ErrorData>
+    ) => BrandedErrorType<BrandString, ErrorData> => {
+        class Base extends CustomError<Record<string, never>> {
+            readonly [brand_symbol] = brand;
+        }
+        Base.prototype.name = brand_string;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return
+        return Base as any;
+    };
+
+    return BrandedError(brand_string);
+}
+
+/**
+ * Factory namespace for creating and managing branded types.
+ * Provides utilities to apply runtime brands to values, create discriminated error types,
+ * and access the brand symbol for type narrowing in union discriminants.
+ *
+ * @property apply - Applies a runtime brand to a value, creating a nominal type
+ * @property symbol - A unique symbol used for brands. Guaranteed not to conflict with other properties
+ * @property Error - Factory for branded error classes that can be reliably discriminated at runtime.
+ */
+const brand = {
+    /** Applies a runtime brand to a value, creating a nominal type. */
+    apply: apply_brand,
+    /** Unique symbol used to store and access brand identifiers. */
+    symbol: brand_symbol,
+    /** Creates a branded error class factory for discriminated error handling. */
+    Error: branded_error,
+};
+
+Object.freeze(brand);
+export { brand, type Brand, apply_brand, brand_symbol, branded_error };

--- a/src/brand/error.test.ts
+++ b/src/brand/error.test.ts
@@ -1,0 +1,345 @@
+/*
+Copyright (c) 2025 Allan Deutsch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import { test } from "node:test";
+import assert from "node:assert";
+import { brand_symbol, type Brand, brand, branded_error } from "./brand.ts";
+import { Assert, type Check } from "../assert/index.ts";
+
+class MyError extends brand.Error("MyError") {}
+class ValidationError extends brand.Error("ValidationError")<{
+    field: string;
+    reason?: string;
+}> {}
+class NetworkError extends brand.Error("NetworkError")<{
+    statusCode?: number;
+    url: string;
+}> {}
+class DataError extends brand.Error("DataError")<{
+    code: number;
+    metadata: string;
+    details: { reason: string; timestamp: number };
+}> {}
+
+await test("branded_error", async (t) => {
+    await t.test("should create error with tag only", () => {
+        const error = new MyError();
+
+        Assert<Check.Equal<(typeof error)[typeof brand_symbol], "MyError">>();
+
+        assert.ok(error instanceof Error);
+        assert.ok(error instanceof MyError);
+        assert.strictEqual(error[brand_symbol], "MyError");
+        assert.strictEqual(error.message, "MyError");
+        assert.strictEqual(error.name, "MyError");
+    });
+
+    await t.test("should create error with custom data", () => {
+        const error = new ValidationError({
+            reason: "invalid format",
+            field: "email",
+        });
+
+        Assert<
+            Check.Equal<(typeof error)[typeof brand_symbol], "ValidationError">
+        >();
+        Assert<Check.Extends<typeof error, Brand<Error, "ValidationError">>>();
+        Assert<Check.Equal<typeof error.field, string>>();
+        Assert<Check.Equal<typeof error.reason, string | undefined>>();
+
+        assert.strictEqual(error.field, "email");
+        assert.strictEqual(error.reason, "invalid format");
+        assert.ok(error instanceof Error);
+        assert.strictEqual(error[brand_symbol], "ValidationError");
+    });
+
+    await t.test("should create error with optional data", () => {
+        const error1 = new NetworkError({ url: "https://example.com" });
+        Assert<Check.Equal<typeof error1.url, string>>();
+        Assert<Check.Equal<typeof error1.statusCode, number | undefined>>();
+
+        assert.strictEqual(error1.url, "https://example.com");
+        assert.strictEqual(error1.statusCode, undefined);
+
+        const error2 = new NetworkError({
+            url: "https://example.com",
+            statusCode: 404,
+        });
+        assert.strictEqual(error2.statusCode, 404);
+    });
+
+    await t.test("should spread data properties onto error instance", () => {
+        const error = new DataError({
+            code: 500,
+            metadata: "test",
+            details: { reason: "TestReason", timestamp: Date.now() },
+        });
+
+        Assert<Check.Equal<typeof error.code, number>>();
+        Assert<Check.Equal<typeof error.metadata, string>>();
+
+        assert.strictEqual(error.code, 500);
+        assert.strictEqual(error.metadata, "test");
+        assert.ok(Object.hasOwn(error, "code"));
+        assert.ok(Object.hasOwn(error, "metadata"));
+    });
+
+    await t.test("should use tag as default message", () => {
+        class MyError extends branded_error("MyError") {}
+        const error = new MyError();
+
+        assert.strictEqual(error.message, "MyError");
+    });
+
+    await t.test("should use custom message when provided", () => {
+        class MyError extends branded_error("MyError") {}
+        const error = new MyError({ message: "Custom error message" });
+
+        assert.strictEqual(error.message, "Custom error message");
+        assert.strictEqual(error[brand_symbol], "MyError");
+    });
+
+    await t.test(
+        "should combine tag and custom data with custom message",
+        () => {
+            class ValidationError extends branded_error("ValidationError")<{
+                field: string;
+            }> {}
+
+            const error = new ValidationError({
+                field: "email",
+                message: "Email validation failed",
+            });
+
+            assert.strictEqual(error.message, "Email validation failed");
+            assert.strictEqual(error.field, "email");
+            assert.strictEqual(error[brand_symbol], "ValidationError");
+        }
+    );
+
+    await t.test("should have correct name property", () => {
+        class MyError extends branded_error("MyError") {}
+        const error = new MyError();
+
+        assert.strictEqual(error.name, "MyError");
+    });
+
+    await t.test("should have stack trace", () => {
+        class MyError extends branded_error("MyError") {}
+        const error = new MyError();
+
+        assert.ok(error.stack);
+        assert.ok(error.stack?.includes("MyError"));
+    });
+
+    await t.test("should preserve custom data properties", () => {
+        const error = new DataError({
+            code: 500,
+            metadata: "test",
+            details: { reason: "Internal", timestamp: Date.now() },
+        });
+
+        Assert<Check.Equal<typeof error.code, number>>();
+        Assert<Check.Equal<typeof error.details.reason, string>>();
+        Assert<Check.Equal<typeof error.details.timestamp, number>>();
+
+        assert.strictEqual(error.code, 500);
+        assert.strictEqual(error.details.reason, "Internal");
+        assert.ok(typeof error.details.timestamp === "number");
+    });
+
+    await t.test("should discriminate by brand symbol", () => {
+        type ErrorUnion =
+            | InstanceType<typeof MyError>
+            | InstanceType<typeof ValidationError>;
+
+        const error: ErrorUnion = new MyError() as ErrorUnion;
+        const errorBrand = error[brand_symbol];
+
+        Assert<Check.Equal<typeof errorBrand, "MyError" | "ValidationError">>();
+
+        if (errorBrand === "MyError") {
+            assert.ok(true);
+        } else {
+            assert.fail("Should be MyError");
+        }
+    });
+
+    await t.test("should discriminate by brand with switch", () => {
+        type ErrorUnion =
+            | InstanceType<typeof MyError>
+            | InstanceType<typeof ValidationError>;
+
+        const errors: ErrorUnion[] = [
+            new MyError(),
+            new ValidationError({ field: "test" }),
+        ];
+        const error = errors[1]!;
+        const tag = error[brand_symbol];
+
+        switch (tag) {
+            case "MyError":
+                assert.fail("The wrong branch was triggered.");
+            case "ValidationError":
+                assert.ok(true);
+                break;
+        }
+    });
+
+    await t.test("should work with different data shapes", () => {
+        type AppError =
+            | InstanceType<typeof NetworkError>
+            | InstanceType<typeof ValidationError>;
+
+        const error: AppError = new ValidationError({
+            field: "email",
+            reason: "test",
+        });
+        const errorBrand = error[brand_symbol];
+
+        if (errorBrand === "ValidationError") {
+            assert.strictEqual(error.field, "email");
+        } else {
+            assert.fail("Should be ValidationError");
+        }
+    });
+
+    await t.test("should work with instanceof", () => {
+        class MyError extends branded_error("MyError") {}
+        class OtherError extends branded_error("OtherError") {}
+
+        const error = new MyError();
+
+        assert.ok(error instanceof MyError);
+        assert.ok(error instanceof Error);
+        assert.ok(!(error instanceof OtherError));
+    });
+
+    await t.test("should be throwable", () => {
+        class MyError extends branded_error("MyError") {}
+
+        assert.throws(
+            () => {
+                throw new MyError();
+            },
+            (err: unknown) => {
+                if (err instanceof MyError) {
+                    return err[brand_symbol] === "MyError";
+                }
+                return false;
+            }
+        );
+    });
+
+    await t.test("should preserve data when thrown", () => {
+        try {
+            throw new DataError({
+                code: 404,
+                metadata: "not found",
+                details: { reason: "NotFound", timestamp: Date.now() },
+            });
+        } catch (err) {
+            assert.ok(err instanceof DataError);
+            if (err instanceof DataError) {
+                assert.strictEqual(err.code, 404);
+                assert.strictEqual(err[brand_symbol], "DataError");
+            }
+        }
+    });
+
+    await t.test("should have brand_symbol property", () => {
+        class MyError extends branded_error("MyError") {}
+        const error = new MyError();
+
+        assert.strictEqual(error[brand_symbol], "MyError");
+        assert.ok(brand_symbol in error);
+    });
+
+    await t.test("should have readonly brand at type level", () => {
+        class MyError extends branded_error("MyError") {}
+        const error = new MyError();
+
+        Assert<Check.Equal<(typeof error)[typeof brand_symbol], "MyError">>();
+        assert.strictEqual(error[brand_symbol], "MyError");
+    });
+
+    await t.test("should freeze the brand namespace", () => {
+        assert.ok(Object.isFrozen(brand));
+    });
+
+    await t.test("should handle complex nested data", () => {
+        class ComplexError extends branded_error("ComplexError")<{
+            nested: {
+                deep: {
+                    value: string;
+                };
+            };
+        }> {}
+
+        const error = new ComplexError({
+            nested: { deep: { value: "test" } },
+        });
+
+        Assert<Check.Equal<typeof error.nested.deep.value, string>>();
+        assert.strictEqual(error.nested.deep.value, "test");
+    });
+
+    await t.test("should handle array data", () => {
+        class ArrayError extends branded_error("ArrayError")<{
+            items: string[];
+        }> {}
+
+        const error = new ArrayError({ items: ["a", "b", "c"] });
+
+        Assert<Check.Extends<typeof error.items, string[]>>();
+        assert.deepStrictEqual(error.items, ["a", "b", "c"]);
+    });
+
+    await t.test("should extend standard Error", () => {
+        class MyError extends branded_error("MyError") {}
+        const error = new MyError();
+
+        assert.ok(error instanceof Error);
+    });
+
+    await t.test("should work in catch blocks expecting Error", () => {
+        class MyError extends branded_error("MyError") {}
+
+        try {
+            throw new MyError({ message: "test error" });
+        } catch (err) {
+            assert.ok(err instanceof Error);
+            if (err instanceof Error) {
+                assert.strictEqual(err.message, "test error");
+            }
+        }
+    });
+
+    await t.test("should be compatible with Brand<Error, Tag>", () => {
+        class MyError extends branded_error("MyError") {}
+        const error = new MyError(); // eslint-disable-line @typescript-eslint/no-unused-vars
+
+        Assert<Check.Extends<typeof error, Brand<Error, "MyError">>>();
+    });
+
+    await t.test("should allow brand.get() on error instances", () => {
+        const myError = new MyError();
+        const validationError = new ValidationError({ field: "test" });
+
+        const brandA = myError[brand_symbol];
+        const brandB = validationError[brand_symbol];
+
+        Assert<Check.Equal<typeof brandA, "MyError">>();
+        Assert<Check.Equal<typeof brandB, "ValidationError">>();
+
+        assert.strictEqual(brandA, "MyError");
+        assert.strictEqual(brandB, "ValidationError");
+    });
+});

--- a/src/brand/index.ts
+++ b/src/brand/index.ts
@@ -8,18 +8,4 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-/**
- * typesafe-ts: TypeScript utilities for writing safer, more correct code
- *
- * This package provides monadic types and utilities that help prevent common runtime errors
- * by making potential failures explicit in the type system, along with ESLint rules to enforce their usage.
- */
-
-// Export Optional monad and related utilities
-export * from "./optional/index.js";
-
-// Export Result monad and related utilities
-export * from "./result/index.js";
-
-// Export Brand type utilities
-export * from "./brand/index.js";
+export { brand, type Brand, apply_brand, branded_error } from "./brand.js";

--- a/src/brand/readme.md
+++ b/src/brand/readme.md
@@ -1,0 +1,145 @@
+# Brand
+
+The `brand` utility creates nominal types in TypeScript by applying runtime brands to values. This allows you to distinguish between structurally identical types at compile time and provides reliable runtime discrimination for union types.
+
+TypeScript's structural type system treats types with identical structure as assignable to each other. Brands prevent this by:
+
+1. Creating nominal types that are not assignable despite identical structure
+2. Providing runtime discrimination that works reliably, even where `instanceof` does not
+3. Using a unique symbol to guarantee no conflicts with other properties
+
+## API Reference
+
+`brand` is fully documented inline. The best way to view its documentation is in your editor, while using it. You can also view the documentation for each method [in this source code](./brand.ts).
+
+```ts
+// Type for branded values
+export type Brand<T extends BrandableTypes, Brand extends string> = T & {
+    readonly [brand_symbol]: Brand;
+};
+
+export const brand = {
+    apply, // Applies a runtime brand to a value
+    symbol, // Unique symbol used to store brand identifiers
+    Error, // Creates branded error class factories
+};
+```
+
+## Usage
+
+### Creating Nominal Types
+
+Prevent accidental mixing of structurally identical types:
+
+```ts
+import { brand, type Brand } from "typesafe-ts/brand";
+
+type UserId = Brand<{ id: string }, "UserId">;
+type ProductId = Brand<{ id: string }, "ProductId">;
+
+const userId: UserId = brand.apply({ id: "user-123" }, "UserId");
+const productId: ProductId = brand.apply({ id: "prod-456" }, "ProductId");
+
+function getUser(id: UserId) {
+    // Fetch user by id
+}
+
+getUser(userId); // ✅ OK
+getUser(productId); // ❌ Type error: ProductId is not assignable to UserId
+```
+
+### Discriminated Unions
+
+Brands provide reliable runtime discrimination. Unlike `instanceof`, which can fail across iframe boundaries, after bundling, or with mocked classes, brands use a unique symbol that works consistently:
+
+```ts
+import { brand } from "typesafe-ts/brand";
+
+class ValidationError extends brand.Error("ValidationError")<{
+    field: string;
+}> {}
+
+class NetworkError extends brand.Error("NetworkError")<{
+    statusCode: number;
+}> {}
+
+type AppError = ValidationError | NetworkError;
+
+function handleError(error: AppError) {
+    switch (error[brand.symbol]) {
+        case "ValidationError":
+            console.log(`Validation failed for ${error.field}`);
+            break;
+        case "NetworkError":
+            console.log(`Network error: ${error.statusCode}`);
+            break;
+    }
+}
+
+handleError(new ValidationError({ field: "email" }));
+// Output: Validation failed for email
+```
+
+### Custom Error Classes
+
+The `brand.Error()` factory creates error classes with custom data fields:
+
+```ts
+import { brand } from "typesafe-ts/brand";
+
+class TooShortError extends brand.Error("PasswordTooShort")<{
+    minLength: number;
+}> {}
+
+class NoNumberError extends brand.Error("PasswordNoNumber") {}
+
+type ValidationError = TooShortError | NoNumberError;
+
+function validatePassword(password: string): ValidationError | null {
+    if (password.length < 8) return new TooShortError({ minLength: 8 });
+    if (!/\d/.test(password)) return new NoNumberError();
+    return null;
+}
+
+const error = validatePassword("short");
+if (error) {
+    switch (error[brand.symbol]) {
+        case "PasswordTooShort": // error is narrowed to TooShortError
+            console.log(`Min ${error.minLength} characters`);
+            break;
+        case "PasswordNoNumber": // Error is narrowed to NoNumberError
+            console.log("Must contain a number");
+            break;
+    }
+}
+```
+
+## Notes
+
+### Brandable Types
+
+Only objects and functions can be branded. Primitives must be wrapped:
+
+```ts
+// ✅ Valid
+type UserId = Brand<{ id: string }, "UserId">;
+type Email = Brand<{ value: string }, "Email">;
+
+// ❌ Invalid - primitives cannot be branded
+type InvalidId = Brand<string, "UserId">; // Type error
+```
+
+### Mutation Behavior
+
+`brand.apply()` mutates the input object by adding a non-enumerable property:
+
+```ts
+const obj = { id: "123" };
+const branded = brand.apply(obj, "UserId");
+console.log(obj === branded); // true - same object reference
+```
+
+### When to Use
+
+- Use `brand.apply()` for general nominal types and discriminated unions
+- Use `brand.Error()` when you need Error subclasses with custom data fields and stack traces


### PR DESCRIPTION
## Summary
- Add brand module with support for nominal typing and runtime brand discrimination
- Include branded error utilities for type-safe discriminated error handling